### PR TITLE
Do not apply timezone delta during feed read

### DIFF
--- a/vkfeed/tools/wall_reader.py
+++ b/vkfeed/tools/wall_reader.py
@@ -213,10 +213,7 @@ def read(profile_name, min_timestamp, max_posts_num, foreign_posts, show_photo, 
                     url = _get_profile_url(post['from_id']), img_style = img_style,
                     photo = users[post['from_id']]['photo'], text = text))
 
-        date = (
-            datetime.datetime.fromtimestamp(post['date'])
-            # Take MSK timezone into account
-            + datetime.timedelta(hours = 4))
+        date = datetime.datetime.fromtimestamp(post['date'])
 
         posts.append({
             'title': title,


### PR DESCRIPTION
The timezone delta right now is applied twice: during the read of the wall, and parsing of the wall. This, obviously causes post time to appear  shifted in future by exactly four hours. This patch tackles the issue by deciding to apply timezone delta only once: during parsing of the post, but not reading of the post.